### PR TITLE
chore: copy on OpenAI API equivalence

### DIFF
--- a/docs/cortex-cpp.md
+++ b/docs/cortex-cpp.md
@@ -8,11 +8,13 @@ slug: "cortex-cpp"
 🚧 Cortex.cpp is currently under development. Our documentation outlines the intended behavior of Cortex, which may not yet be fully implemented in the codebase.
 :::
 
-Cortex.cpp is a stateless, C++ server that is 100% compatible with OpenAI API (stateless endpoints).
+Cortex.cpp is a Local AI engine that is used to run and customize LLMs. Cortex can be deployed as a standalone server, or integrated into apps like [Jan.ai](https://jan.ai/)
+
+Cortex's roadmap is to eventually support full OpenAI API-equivalence.
 
 It includes a Drogon server, with request queues, model orchestration logic, and hardware telemetry, and more, for prod environments.
 
-This guide walks you through how Cortex.CPP is designed, the codebase structure, and future plans.
+This guide walks you through how Cortex.cpp is designed, the codebase structure, and future plans.
 
 ## Usage
 

--- a/docs/cortex-platform/about.mdx
+++ b/docs/cortex-platform/about.mdx
@@ -16,7 +16,7 @@ import TabItem from "@theme/TabItem";
 
 ## OpenAI API Equivalence
 
-Cortex aims to be fully compatible with [OpenAI API](https://platform.openai.com/docs/api-reference) endpoints.
+Cortex's roadmap is to eventually support full [OpenAI API](https://platform.openai.com/docs/api-reference) equivalence.
 
 Our goal is to help developers to build applications with on-device AI and with a fully open-source stack. 
 

--- a/docs/embeddings.mdx
+++ b/docs/embeddings.mdx
@@ -13,7 +13,7 @@ import TabItem from "@theme/TabItem";
 
 An embedding is a vector that represents a piece of text, with the distance between vectors indicating similarity, which means closer distances mean more similar texts, while farther distances mean less similar texts.
 :::note
-The Cortex Embeddings feature is fully compatible with OpenAI-compatible endpoints.
+The Cortex Embeddings feature is fully compatible with OpenAI's [Embeddings API](https://platform.openai.com/docs/api-reference/embeddings) endpoints.
 :::
 
 ## Usage

--- a/docs/using-models.mdx
+++ b/docs/using-models.mdx
@@ -11,7 +11,7 @@ import TabItem from "@theme/TabItem";
 🚧 Cortex.cpp is currently under development. Our documentation outlines the intended behavior of Cortex, which may not yet be fully implemented in the codebase.
 :::
 
-Cortex's Models API is compatible with OpenAI’s [Models API](https://platform.openai.com/docs/api-reference/models) endpoint. It is a fork of the OpenAI API used for model management. Additionally, Cortex exposes lower-level operations for managing models like downloading models from a model hub and model loading.
+Cortex's Models API is compatible with OpenAI’s [Models](https://platform.openai.com/docs/api-reference/models) endpoint. It is a fork of the OpenAI API used for model management. Additionally, Cortex exposes lower-level operations for managing models like downloading models from a model hub and model loading.
 
 ## Model Operation
 Model Operation allows you to pull, run, and stop models.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -54,7 +54,7 @@ const config: Config = {
   title: "Cortex",
   titleDelimiter: "-",
   tagline:
-    "Cortex is an openAI-compatible local AI server that developers can use to build LLM apps. It is packaged with a Docker-inspired command-line interface and a Typescript client library. It can be used as a standalone server, or imported as a library.",
+    "Cortex is an Local AI engine for developers to run and customize Local LLMs. It is packaged with a Docker-inspired command-line interface and a Typescript client library. It can be used as a standalone server, or imported as a library. Cortex's roadmap is to eventually support full OpenAI API-equivalence.",
   favicon: "img/favicons/favicon.ico",
   staticDirectories: ["static"],
 
@@ -373,12 +373,12 @@ const config: Config = {
       {
         name: "description",
         content:
-          "Cortex is an openAI-compatible local AI server that developers can use to build LLM apps. It is packaged with a Docker-inspired command-line interface and a Typescript client library. It can be used as a standalone server, or imported as a library.",
+          "Cortex is an Local AI engine for developers to run and customize Local LLMs. It is packaged with a Docker-inspired command-line interface and a Typescript client library. It can be used as a standalone server, or imported as a library. Cortex's roadmap is to eventually support full OpenAI API-equivalence.",
       },
       {
         name: "og:description",
         content:
-          "Cortex is an openAI-compatible local AI server that developers can use to build LLM apps. It is packaged with a Docker-inspired command-line interface and a Typescript client library. It can be used as a standalone server, or imported as a library.",
+          "Cortex is an Local AI engine for developers to run and customize Local LLMs. It is packaged with a Docker-inspired command-line interface and a Typescript client library. It can be used as a standalone server, or imported as a library. Cortex's roadmap is to eventually support full OpenAI API-equivalence.",
       },
     ],
 

--- a/static/openapi/jan.json
+++ b/static/openapi/jan.json
@@ -1176,7 +1176,7 @@
     },
     "info": {
         "title": "Cortex API",
-        "description": "Cortex API provides a command-line interface (CLI) for seamless interaction with Large Language Models (LLMs). It is fully compatible with the [OpenAI API](https://platform.openai.com/docs/api-reference) and enables straightforward command execution and management of LLM interactions.",
+        "description": "Cortex API enables API commands for seamless interaction with LLMs.",
         "version": "1.0",
         "contact": {}
     },


### PR DESCRIPTION
## Describe Your Changes
- remove `Cortex is 100% compatible with OpenAI Platform`
- reword to `Cortex's roadmap is to eventually support full OpenAI API-equivalence`